### PR TITLE
Force a branch sync from external script

### DIFF
--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/FreeStyleMultiBranchProject.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/FreeStyleMultiBranchProject.java
@@ -572,6 +572,12 @@ public class FreeStyleMultiBranchProject extends
 		rsp.sendRedirect2(req.getContextPath() + '/' + getParent().getUrl());
 	}
 
+    @RequirePOST
+    public void doSyncBranches(StaplerRequest req, StaplerResponse rsp)
+            throws IOException, InterruptedException {
+            getSyncBranchesTrigger().run();
+    }
+
 	/**
 	 * {@inheritDoc}
 	 */


### PR DESCRIPTION
Do a post to http://my-jenkins/job/MY-JOB/syncBranches to force a branch sync and avoid waiting for execution.
