### PR TITLE
Sync projects only when the configuration has changed

### DIFF
--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
@@ -901,7 +901,7 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 		//endregion AbstractProject mirror
 
 		// TODO run this separately since it can block completion (user redirect) if unable to fetch from repository
-		getSyncBranchesTrigger().run();
+		getSyncBranchesTrigger().run(true);
 	}
 
 	/**
@@ -938,14 +938,14 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 	 * disabled, then calling {@link #_syncBranches(TaskListener)} and logging
 	 * its exceptions to the listener.
 	 */
-	public synchronized void syncBranches(TaskListener listener) {
+	public synchronized void syncBranches(TaskListener listener, boolean forceSync) {
 		if (isDisabled()) {
 			listener.getLogger().println("Project disabled.");
 			return;
 		}
 
 		try {
-			_syncBranches(listener);
+			_syncBranches(listener, forceSync);
 		} catch (Throwable e) {
 			e.printStackTrace(listener.fatalError(e.getMessage()));
 		}
@@ -956,7 +956,7 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 	 * updates all sub-project configurations with the configuration specified
 	 * by this project.
 	 */
-	private synchronized void _syncBranches(TaskListener listener)
+	private synchronized void _syncBranches(TaskListener listener, boolean forceSync)
 			throws IOException, InterruptedException {
 		// No SCM to source from, so delete all the branch projects
 		if (scmSource == null) {
@@ -982,6 +982,7 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 
 		Map<String, SCMHead> branches = new HashMap<String, SCMHead>();
 		Set<String> newBranches = new HashSet<String>();
+		List<P> newBranchProjects = new ArrayList<P>();
 		for (SCMHead head : heads) {
 			String branchName = head.getName();
 			branches.put(branchName, head);
@@ -991,9 +992,10 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 				listener.getLogger().println(
 						"Creating project for branch " + branchName);
 				try {
-					subProjects.put(branchName,
-							createNewSubProject(this, branchName));
+					P subProject = createNewSubProject(this, branchName);
+					subProjects.put(branchName, subProject);
 					newBranches.add(branchName);
+					newBranchProjects.add(subProject);
 				} catch (Throwable e) {
 					e.printStackTrace(listener.fatalError(e.getMessage()));
 				}
@@ -1018,8 +1020,9 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 
 
 		// Sync config for existing branch projects
+		List<P> projectsToSync = forceSync ? getSubProjects() : newBranchProjects;
 		XmlFile configFile = templateProject.getConfigFile();
-		for (P project : getSubProjects()) {
+		for (P project : projectsToSync) {
 			listener.getLogger().println(
 					"Syncing configuration to project for branch "
 							+ project.getName());

--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/SyncBranchesTrigger.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/SyncBranchesTrigger.java
@@ -82,6 +82,10 @@ public class SyncBranchesTrigger extends Trigger<AbstractMultiBranchProject> {
 	 */
 	@Override
 	public void run() {
+		run(false);
+	}
+
+	public void run(boolean forceSync) {
 		/*
 		 * The #start(Item, boolean) method provides the job so this will be null
 		 * only when invoked directly before starting.
@@ -99,7 +103,7 @@ public class SyncBranchesTrigger extends Trigger<AbstractMultiBranchProject> {
 					"Started on " + DateFormat.getDateTimeInstance().format(
 							new Date()));
 
-			job.syncBranches(listener);
+			job.syncBranches(listener, forceSync);
 
 			listener.getLogger().println("Done. Took " + Util.getTimeSpanString(
 					System.currentTimeMillis() - start));


### PR DESCRIPTION
Hi,

Please have a look at the modifications I have made and let me know what you think.

I have not modified the unit tests as I'm currently on windows and there's a known bug that prevents them to pass: https://issues.jenkins-ci.org/browse/JENKINS-21977. But I did test with mvn hpi:run.

I have added a forceSync flag to the method syncBranches which is only set to true when the parent project configuration is modified (called from method doConfigSubmit).

When the SCM trigger runs, then the config will be synced only for new branches, same thing when the branches are introspected using the POST url /syncBranches.

I think this PR would not completely fix #93 and #88 but it should improve the plugin for both.

Thanks