### PR TITLE
Fix #82: Add options for additional behaviours for a git project

### DIFF
--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/SCMOptions.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/SCMOptions.java
@@ -1,0 +1,50 @@
+package com.github.mjdetullio.jenkins.plugins.multibranch;
+
+import hudson.scm.SCM;
+
+import java.io.Serializable;
+import java.lang.reflect.Field;
+
+/**
+ * @author Hiroyuki Wada
+ */
+public class SCMOptions implements Serializable {
+
+	protected SCM scmTemplate;
+
+	public SCMOptions(SCM scm) {
+		this.scmTemplate = scm;
+	}
+
+	public SCM getSCMTemplate() {
+		return scmTemplate;
+	}
+
+	public void apply(SCM scm) throws Exception {
+		// Copy properties for all SCM
+		apply(scm, "browser", scmTemplate.getBrowser());
+
+		// Copy properties for GitSCM
+		if (scm.getType().equals("hudson.plugins.git.GitSCM")) {
+			apply(scm, "gitTool");
+			apply(scm, "extensions");
+		}
+	}
+
+	private void apply(SCM dest, String name, Object value) throws Exception {
+		Field field = dest.getClass().getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(dest, value);
+	}
+
+	private void apply(SCM dest, String name) throws Exception {
+		Field source = scmTemplate.getClass().getDeclaredField(name);
+		source.setAccessible(true);
+
+		Field field = dest.getClass().getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(dest, source.get(scmTemplate));
+	}
+
+	private static final long serialVersionUID = 1L;
+}

--- a/src/main/resources/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject/configure-entries-git.jelly
+++ b/src/main/resources/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject/configure-entries-git.jelly
@@ -1,0 +1,45 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2015, Sun Microsystems, Inc., Kohsuke Kawaguchi,
+Eric Lefevre-Ardant, id:cactusman, Yahoo! Inc., Matthew DeTullio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!--
+  Git SCM Plugin config
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form"
+		xmlns:t="/lib/hudson" xmlns:p="/lib/hudson/project">
+
+	<j:if test="${descriptor.showGitToolOptions()}">
+		<f:entry title="${%Git executable}" field="gitTool">
+			<f:select />
+		</f:entry>
+	</j:if>
+
+	<t:listScmBrowsers name="git.browser" />
+
+	<f:entry title="${%Additional Behaviours}">
+		<!-- TODO: switch to <f:repeatableHeteroList field="extensions"> -->
+		<f:hetero-list name="extensions" items="${instance.extensions}" descriptors="${descriptor.getExtensionDescriptors()}"
+			hasHeader="true" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject/configure-entries.jelly
+++ b/src/main/resources/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject/configure-entries.jelly
@@ -64,6 +64,7 @@ THE SOFTWARE.
 				<div class="warning">${%No compatible SCMs found. Try installing an SCM plugin that implements jenkins.scm.api.SCMSource.}</div>
 			</f:block>
 		</j:if>
+		
 		<j:forEach var="idx" begin="0" end="${size(scms)-1}">
 			<j:set var="descriptor" value="${scms[idx]}" />
 			<f:radioBlock name="scmSource" value="${idx}"
@@ -73,6 +74,23 @@ THE SOFTWARE.
 						value="${it.getSCMSource().descriptor==descriptor ? it.getSCMSource() : null}" />
 				<st:include from="${descriptor}"
 						page="${descriptor.configPage}" />
+
+				<j:set var="descriptor" value="${it.getSCMDescriptor(descriptor)}" />
+				<j:set var="instance" value="${it.getSCMOptions() != null ? it.getSCMOptions().getSCMTemplate() : null}" />
+				<j:set var="scmd" value="${descriptor}" />
+				<j:set var="scm" value="${instance}" />
+				<f:rowSet name="scmOptions">
+					<f:invisibleEntry>
+						<div style="display:none;">
+							<f:textbox name="kind" value="${descriptor.getClass().getName()}" />
+						</div>
+					</f:invisibleEntry>
+					
+					<j:catch>
+						<st:include from="${it}"
+							page="configure-entries-${descriptor.getDisplayName().toLowerCase()}.jelly" />
+					</j:catch>
+				</f:rowSet>
 			</f:radioBlock>
 		</j:forEach>
 	</f:section>


### PR DESCRIPTION
There isn't  a way to set any Additional Behaviours for a git project because Multi-Branch Project Plugin depends on SCM API Plugin that is not supported specific git options.
I added more options to this plugin for a git project.