### PR TITLE
fix from JENKINS-42317 to prevent deletion of build history

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.mjdetullio.jenkins.plugins</groupId>
     <artifactId>multi-branch-project-plugin</artifactId>
-    <version>0.7.1-SNAPSHOT</version>
+    <version>0.7.1</version>
     <packaging>hpi</packaging>
 
     <parent>

--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/TemplateDrivenBranchProjectFactory.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/TemplateDrivenBranchProjectFactory.java
@@ -73,6 +73,15 @@ public abstract class TemplateDrivenBranchProjectFactory<P extends AbstractProje
          * or that it will be converted to Branch.Dead and the guessed values for sourceId and properties won't matter.
          */
         if (property == null) {
+            // Don't try to set a branch on the template folder,
+            // otherwise all your history will disappear.
+            // There might be nicer fix, but this works
+            // from JENKINS-42317
+            if ("template".equals(project.getName())) {
+                LOGGER.log(Level.INFO, "Skip branch setting for template " +
+                    project.getFullName());
+                return null;
+            }
             Branch branch = new Branch("unknown", new SCMHead(project.getDisplayName()), project.getScm(),
                     Collections.<BranchProperty>emptyList());
             setBranch(project, branch);


### PR DESCRIPTION
fix the issue reported here https://issues.jenkins.io/browse/JENKINS-42317 that would cause the deletion of all build history when enabling certain integrations (ex. Artifactory Integration)